### PR TITLE
Update runtime to 24.08

### DIFF
--- a/io.sourceforge.Pixelitor.json
+++ b/io.sourceforge.Pixelitor.json
@@ -1,7 +1,7 @@
 {
     "id": "io.sourceforge.Pixelitor",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "24.08",
     "command": "pixelitor",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions": ["org.freedesktop.Sdk.Extension.openjdk"],
@@ -46,8 +46,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/flatpak/flatpak-xdg-utils.git",
-                    "tag": "1.0.5",
-                    "commit": "5ba39872f81bf8d98d58c5f8acb86604645be468"
+                    "tag": "1.0.6",
+                    "commit": "05abdd7421688be5835a6b12f2b068086c38d4aa"
                 }
             ]
         },

--- a/io.sourceforge.Pixelitor.metainfo.xml
+++ b/io.sourceforge.Pixelitor.metainfo.xml
@@ -6,7 +6,7 @@
   <project_license>GPL-3.0-only</project_license>
   <developer_name>László Balázs-Csíki</developer_name>
   <name>Pixelitor</name>
-  <summary>Pixelitor is an open source image editor</summary>
+  <summary>Open source image editor</summary>
   <description>
     <p>
     	Pixelitor is an advanced image editor with support for layers, layer masks, text layers, multiple undo, blending modes, cropping, Gaussian blurring, unsharp masking, histograms, etc. It has more than 110 image filters and color adjustments, some of which are unique to Pixelitor. Some of the gradients are unique to Pixelator.


### PR DESCRIPTION
- Update runtime to `24.08` so that flathub app page does not shows warning "_Uses and end-of-life runtime_".

- Re-phrase summary according to guidelines[1] i.e. remove app name and don't use starting article.

- Update flatpak-xdg-utils version.

[1] https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines#summary